### PR TITLE
Add smooth loading images

### DIFF
--- a/components/navbar/NavBar.tsx
+++ b/components/navbar/NavBar.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@mui/icons-material';
-import { AppBar, Box, Drawer, IconButton, Stack, styled, useMediaQuery, useTheme } from '@mui/material';
+import { AppBar, Box, Drawer, IconButton, Stack, styled, useMediaQuery, useTheme, Fade } from '@mui/material';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
@@ -19,6 +19,7 @@ const NavBar = ({ isAdmin }: { isAdmin: boolean }) => {
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   const [navColor, setNavColor] = useState<string>('#ffffff00');
   const [blur, setBlur] = useState<number>(0);
+  const [showImage, setShowImage] = useState<boolean>(false);
   
   const theme = useTheme();
   const mobileQuery = useMediaQuery(theme.breakpoints.down('md'));
@@ -81,14 +82,20 @@ const NavBar = ({ isAdmin }: { isAdmin: boolean }) => {
           href='/'
           passHref
         >
-          <LogoWrapper>
-            <Image
-              src={`${prefix}/ntnui-logo.png`}
-              alt='ntnui-logo'
-              layout='fill'
-              priority
-            />
-          </LogoWrapper>
+          <Fade
+            appear={false}
+            in={showImage}
+            timeout={2000}
+          >
+            <LogoWrapper>
+              <Image
+                src={`${prefix}/ntnui-logo.png`}
+                alt='ntnui-logo'
+                layout='fill'
+                onLoadingComplete={() => setShowImage(true)}
+              />
+            </LogoWrapper>
+          </Fade>
         </Link>
         {mobileQuery ?
           <IconButton

--- a/components/navbar/NavBar.tsx
+++ b/components/navbar/NavBar.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@mui/icons-material';
-import { AppBar, Box, Drawer, IconButton, Stack, styled, useMediaQuery, useTheme, Fade } from '@mui/material';
+import { AppBar, Box, Drawer, IconButton, Stack, styled, useMediaQuery, useTheme } from '@mui/material';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
@@ -86,6 +86,7 @@ const NavBar = ({ isAdmin }: { isAdmin: boolean }) => {
               src={`${prefix}/ntnui-logo.png`}
               alt='ntnui-logo'
               layout='fill'
+              priority
             />
           </LogoWrapper>
         </Link>

--- a/components/navbar/NavBar.tsx
+++ b/components/navbar/NavBar.tsx
@@ -19,7 +19,6 @@ const NavBar = ({ isAdmin }: { isAdmin: boolean }) => {
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
   const [navColor, setNavColor] = useState<string>('#ffffff00');
   const [blur, setBlur] = useState<number>(0);
-  const [showImage, setShowImage] = useState<boolean>(false);
   
   const theme = useTheme();
   const mobileQuery = useMediaQuery(theme.breakpoints.down('md'));
@@ -82,20 +81,13 @@ const NavBar = ({ isAdmin }: { isAdmin: boolean }) => {
           href='/'
           passHref
         >
-          <Fade
-            appear={false}
-            in={showImage}
-            timeout={2000}
-          >
-            <LogoWrapper>
-              <Image
-                src={`${prefix}/ntnui-logo.png`}
-                alt='ntnui-logo'
-                layout='fill'
-                onLoadingComplete={() => setShowImage(true)}
-              />
-            </LogoWrapper>
-          </Fade>
+          <LogoWrapper>
+            <Image
+              src={`${prefix}/ntnui-logo.png`}
+              alt='ntnui-logo'
+              layout='fill'
+            />
+          </LogoWrapper>
         </Link>
         {mobileQuery ?
           <IconButton

--- a/components/pages/board/BoardMembers.tsx
+++ b/components/pages/board/BoardMembers.tsx
@@ -1,7 +1,7 @@
-import { Box, Card, CardContent, CardMedia, Divider, Stack, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Stack, useMediaQuery, useTheme } from '@mui/material';
 import { Fade } from 'react-awesome-reveal';
 import { useTranslation } from 'next-export-i18n';
-import { prefix } from '../../../utils/prefix';
+import BoardCard from './content/CardComponents';
 
 const BoardMembers = () => {
   const { t } = useTranslation();
@@ -23,84 +23,13 @@ const BoardMembers = () => {
         direction={i % 2 === 0 ? 'left' : 'right'}
         fraction={0.5}
       >
-        <Card
-          elevation={3}
-          sx={{
-            width: '95vw',
-            maxWidth: '50rem',
-            marginRight: !marginQuery && i % 2 === 0 ? '6rem': '0',
-            marginLeft: !marginQuery && i % 2 !== 0 ? '6rem': '0'
-          }}
-        >
-          <Stack
-            direction={mobileQuery ? 'column' : 'row'}
-          >
-            {i % 2 === 0 && !mobileQuery ?
-            <CardMedia
-              component='img'
-              image={`${prefix}/board/${member[0]}.jpeg`}
-              alt={`${member[0]}`}
-              sx={{
-                width: '15rem'
-              }}
-            /> :
-            null}
-            <CardContent>
-              <Stack
-                height='100%'
-                gap='3rem'
-                justifyContent='space-between'
-              >
-              <Stack
-                gap='0.5rem'
-              >
-                <Typography
-                  variant='h4'
-                  textAlign='center'
-                  color={theme.palette.mode === 'dark' ? 'primary.light' : 'primary.dark'}
-                >
-                  {member[1][0]}
-                </Typography>
-                <Divider
-                  sx={{
-                    color: theme.palette.text.primary
-                  }}
-                />
-                <Typography
-                  color='text.secondary'
-                >
-                  {member[1][3]}
-                </Typography>
-              </Stack>
-                <Box
-                  color='primary.main'
-                >
-                  <Typography
-                    fontWeight='bold'
-                    textAlign={i % 2 === 0 ? 'right' : 'left'}
-                  >
-                    {member[1][1]}
-                  </Typography>
-                  <Typography
-                    textAlign={i % 2 === 0 ? 'right' : 'left'}
-                  >
-                    {member[1][2]}
-                  </Typography>
-                </Box>
-              </Stack>
-            </CardContent>
-            {i % 2 !== 0 || mobileQuery ?
-            <CardMedia
-              component='img'
-              image={`${prefix}/board/${member[0]}.jpeg`}
-              alt={`${member[0]}`}
-              sx={{
-                width: mobileQuery ? '100%' : '15rem'
-              }}
-            /> :
-            null}
-          </Stack>
-        </Card>
+        <BoardCard
+          mobileQuery={mobileQuery}
+          marginQuery={marginQuery}
+          member={member}
+          darkMode={theme.palette.mode === 'dark'}
+          i={i}
+        />
       </Fade>))}
     </Stack>
   );

--- a/components/pages/board/content/CardComponents.tsx
+++ b/components/pages/board/content/CardComponents.tsx
@@ -1,0 +1,136 @@
+import { Box, Card, CardContent, CardMedia, Divider, Fade, Stack, styled, Typography } from '@mui/material';
+import Image from 'next/image';
+import { useState } from 'react';
+import { prefix } from '../../../../utils/prefix';
+
+type BoardCardProps = {
+  mobileQuery: boolean,
+  marginQuery: boolean,
+  member: any,
+  darkMode: boolean,
+  i: number
+}
+
+type BoardCardMediaProps = {
+  mobileQuery: boolean,
+  member: any
+}
+
+type BoardCardContentProps = {
+  member: any,
+  darkMode: boolean,
+  i: number
+}
+
+const ImageWrapper = styled('div')({
+  position: 'relative',
+  height: '100%'
+});
+
+const BoardCard = (props: BoardCardProps) => {
+  const { mobileQuery, marginQuery, member, darkMode, i } = props;
+
+  return (
+    <Card
+      elevation={3}
+      sx={{
+        width: '95vw',
+        maxWidth: '50rem',
+        marginRight: !marginQuery && i % 2 === 0 ? '6rem': '0',
+        marginLeft: !marginQuery && i % 2 !== 0 ? '6rem': '0'
+      }}
+    >
+      <Stack
+        direction={mobileQuery ? 'column' :
+          i % 2 === 0 ? 'row' : 'row-reverse'}
+      >
+        <BoardCardMedia member={member} mobileQuery={mobileQuery} />
+        <BoardCardContent member={member} darkMode={darkMode} i={i} />
+      </Stack>
+    </Card>
+  );
+}
+
+const BoardCardMedia = (props: BoardCardMediaProps) => {
+  const { mobileQuery, member } = props;
+
+  const [showImage, setShowImage] = useState<boolean>(false);
+
+  return (
+    <CardMedia>
+      <Fade
+        appear={false}
+        in={showImage}
+        timeout={2000}
+      >
+        <ImageWrapper
+          sx={{
+            width: mobileQuery ? '100%' : '15rem',
+            minHeight: mobileQuery ? '30rem' : '25rem'
+          }}
+        >
+          <Image
+            src={`${prefix}/board/${member[0]}.jpeg`}
+            alt={member[0]}
+            layout='fill'
+            objectFit='cover'
+            onLoadingComplete={() => setShowImage(true)}
+          />
+        </ImageWrapper>
+      </Fade>
+    </CardMedia>
+  );
+}
+
+const BoardCardContent = (props: BoardCardContentProps) => {
+  const { member, darkMode, i } = props;
+
+  return (
+    <CardContent>
+      <Stack
+        height='100%'
+        gap='3rem'
+        justifyContent='space-between'
+      >
+        <Stack
+          gap='0.5rem'
+        >
+          <Typography
+            variant='h4'
+            textAlign='center'
+            color={darkMode ? 'primary.light' : 'primary.dark'}
+          >
+            {member[1][0]}
+          </Typography>
+          <Divider
+            sx={{
+              color: 'text.primary'
+            }}
+          />
+          <Typography
+            color='text.secondary'
+          >
+            {member[1][3]}
+          </Typography>
+        </Stack>
+        <Box
+          color='primary.main'
+        >
+          <Typography
+            fontWeight='bold'
+            textAlign={i % 2 === 0 ? 'right' : 'left'}
+          >
+            {member[1][1]}
+          </Typography>
+          <Typography
+            textAlign={i % 2 === 0 ? 'right' : 'left'}
+          >
+            {member[1][2]}
+          </Typography>
+        </Box>
+      </Stack>
+    </CardContent>
+  );
+}
+
+export default BoardCard;

--- a/components/pages/landing/LandingContent.tsx
+++ b/components/pages/landing/LandingContent.tsx
@@ -18,7 +18,7 @@ const LandingContent = () => {
         duration={1000}
         triggerOnce
         direction='up'
-        fraction={0.5}
+        fraction={0.25}
       >
         <Stack
           gap='0.5rem'


### PR DESCRIPTION
Did not keep the smooth loading on the ntnui logo in the navbar as it kept fading in on every page. Looked kind of bad. Should use a context if this functionality is desired.